### PR TITLE
Add v8 Releases to dropdown

### DIFF
--- a/server/git/git.js
+++ b/server/git/git.js
@@ -35,7 +35,7 @@ const getRepoTags = async () => {
   if (isRepo) {
     try {
       const allTags = await git(tasmotaRepo).tags();
-      const tags = allTags.all.filter(t => t.startsWith('v6') || t.startsWith('v7'));
+      const tags = allTags.all.filter(t => t.startsWith('v6') || t.startsWith('v7') || t.startsWith('v8'));
       return [...tags, edgeBranch];
     } catch (e) {
       debug(message);


### PR DESCRIPTION
Tasmota has reached v8.1.0 . getRepoTags filters for v6 and v7. Added v8. Tested locally and successfully compiled