### PR TITLE
Fix checking both rules and script

### DIFF
--- a/src/components/AppStepper/FeaturesStep/AvailableFeatures.js
+++ b/src/components/AppStepper/FeaturesStep/AvailableFeatures.js
@@ -169,7 +169,7 @@ const availableFeatures = [
     show: true,
     description: 'stepFeaturesScriptDesc',
     tooltip: 'stepFeaturesScriptTooltip',
-    exclude: ['USE_RULES'],
+    exclude: ['rules'],
   },
   {
     name: 'USE_TIMERS',


### PR DESCRIPTION
Checking Scripts leave Rules checked (it selected by default), but only USE_RULES removed.
USE_EXPRESSION and SUPPORT_IF_STATEMENT still in the user_config_override.h.