### PR TITLE
Update AvailableBoards.js

### DIFF
--- a/src/components/AppStepper/FeaturesStep/AvailableBoards.js
+++ b/src/components/AppStepper/FeaturesStep/AvailableBoards.js
@@ -1,7 +1,105 @@
 const availableBoards = [
+  // esp32
+  {
+    name: 'esp32',
+    description: 'ESP32 (generic)',
+    default: false,
+    show: true,
+    platformio_entries: {
+      extends: 'env:tasmota32',
+    },
+    tooltip: '',
+    include_features: [],
+    exclude_features: [],
+    defines: {},
+  },
+  // esp32m5
+  {
+    name: 'esp32m5',
+    description: 'ESP32 (M5Stack Core2)',
+    default: false,
+    show: true,
+    platformio_entries: {
+      extends: 'env:tasmota32',
+      board: 'm5stack-grey',
+      'board_build.f_cpu': '240000000L',
+      'board_build.partitions': 'esp32_partition_app1984k_spiffs12M.csv',
+      build_flags:
+        // eslint-disable-next-line
+        '${common32.build_flags} -DDBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue',
+    },
+    tooltip: '',
+    include_features: ['displays'],
+    exclude_features: [],
+    defines: {
+      MODULE: 'M5STACK_CORE2',
+      FALLBACK_MODULE: 'M5STACK_CORE2',
+      USE_M5STACK_CORE2: true,
+      SAY_TIME: true,
+      USE_WEBRADIO: true,
+      USE_MPU6886: true,
+      USE_UFILESYS: true,
+      USE_SDCARD: true,
+      GUI_TRASH_FILE: true,
+      USE_BMA423: true,
+      JPEG_PICTS: true,
+      USE_FT5206: true,
+      USE_TOUCH_BUTTONS: true,
+      MAX_TOUCH_BUTTONS: 16,
+      USE_SENDMAIL: true,
+      USE_ESP32MAIL: true,
+    },
+  },
+  // esp32odroid-go
+  {
+    name: 'esp32odroid-go',
+    description: 'ESP32 (odroid-go)',
+    default: false,
+    show: true,
+    platformio_entries: {
+      extends: 'env:tasmota32',
+      board: 'odroid_esp32',
+      'board_build.f_cpu': '240000000L',
+      'board_build.partitions': 'esp32_partition_app1984k_spiffs12M.csv',
+      build_flags:
+        // eslint-disable-next-line
+        '${common32.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue',
+    },
+    tooltip: '',
+    include_features: ['displays'],
+    exclude_features: [],
+    defines: {
+      MODULE: 'ODROID_GO',
+      FALLBACK_MODULE: 'ODROID_GO',
+      USE_ODROID_GO: true,
+      USE_UFILESYS: true,
+      USE_SDCARD: true,
+      GUI_TRASH_FILE: true,
+      USE_ADC: true,
+      USE_BLE_ESP32: true,
+      USE_MI_ESP32: true,
+    },
+  },
+  // esp32webcam
+  {
+    name: 'esp32webcam',
+    description: 'ESP32 (webcam)',
+    default: false,
+    show: true,
+    platformio_entries: {
+      extends: 'env:tasmota32',
+      board: 'esp32cam',
+      'board_build.f_cpu': '240000000L',
+    },
+    tooltip: '',
+    include_features: [],
+    exclude_features: [],
+    defines: { USE_WEBCAM: true, USE_MI_ESP32: false },
+  },
+  // esp2866
   {
     name: 'esp8266',
-    description: 'Generic ESP8266',
+    description: 'ESP8266 (generic)',
     default: true,
     show: true,
     platformio_entries: {},
@@ -37,103 +135,6 @@ const availableBoards = [
       USE_TCP_BRIDGE: true,
       USE_ZIGBEE_CHANNEL: 11,
       USE_ZIGBEE_COALESCE_ATTR_TIMER: 350,
-    },
-  },
-  // esp32
-  {
-    name: 'esp32',
-    description: 'Generic ESP32',
-    default: false,
-    show: true,
-    platformio_entries: {
-      extends: 'env:tasmota32',
-    },
-    tooltip: '',
-    include_features: [],
-    exclude_features: [],
-    defines: {},
-  },
-  // esp32webcam
-  {
-    name: 'esp32webcam',
-    description: 'ESP32 webcam',
-    default: false,
-    show: true,
-    platformio_entries: {
-      extends: 'env:tasmota32',
-      board: 'esp32cam',
-      'board_build.f_cpu': '240000000L',
-    },
-    tooltip: '',
-    include_features: [],
-    exclude_features: [],
-    defines: { USE_WEBCAM: true, USE_MI_ESP32: false },
-  },
-  // esp32odroid-go
-  {
-    name: 'esp32odroid-go',
-    description: 'ESP32 odroid-go',
-    default: false,
-    show: true,
-    platformio_entries: {
-      extends: 'env:tasmota32',
-      board: 'odroid_esp32',
-      'board_build.f_cpu': '240000000L',
-      'board_build.partitions': 'esp32_partition_app1984k_spiffs12M.csv',
-      build_flags:
-        // eslint-disable-next-line
-        '${common32.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue',
-    },
-    tooltip: '',
-    include_features: ['displays'],
-    exclude_features: [],
-    defines: {
-      MODULE: 'ODROID_GO',
-      FALLBACK_MODULE: 'ODROID_GO',
-      USE_ODROID_GO: true,
-      USE_UFILESYS: true,
-      USE_SDCARD: true,
-      GUI_TRASH_FILE: true,
-      USE_ADC: true,
-      USE_BLE_ESP32: true,
-      USE_MI_ESP32: true,
-    },
-  },
-  // esp32m5
-  {
-    name: 'esp32m5',
-    description: 'ESP32 M5Stack Core2',
-    default: false,
-    show: true,
-    platformio_entries: {
-      extends: 'env:tasmota32',
-      board: 'm5stack-grey',
-      'board_build.f_cpu': '240000000L',
-      'board_build.partitions': 'esp32_partition_app1984k_spiffs12M.csv',
-      build_flags:
-        // eslint-disable-next-line
-        '${common32.build_flags} -DDBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue',
-    },
-    tooltip: '',
-    include_features: ['displays'],
-    exclude_features: [],
-    defines: {
-      MODULE: 'M5STACK_CORE2',
-      FALLBACK_MODULE: 'M5STACK_CORE2',
-      USE_M5STACK_CORE2: true,
-      SAY_TIME: true,
-      USE_WEBRADIO: true,
-      USE_MPU6886: true,
-      USE_UFILESYS: true,
-      USE_SDCARD: true,
-      GUI_TRASH_FILE: true,
-      USE_BMA423: true,
-      JPEG_PICTS: true,
-      USE_FT5206: true,
-      USE_TOUCH_BUTTONS: true,
-      MAX_TOUCH_BUTTONS: 16,
-      USE_SENDMAIL: true,
-      USE_ESP32MAIL: true,
     },
   },
 ];

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -104,13 +104,6 @@
   "Vietnam": "Vietnam",
 
   "stepVersionCompProgress": "Compiling progress",
-
-  "ESP32 (generic)": "ESP32 (generic)",
-  "ESP32 (M5Stack Core2)": "ESP32 (M5Stack Core2)",
-  "ESP32 (odroid-go)": "ESP32 (odroid-go)",
-  "ESP32 (webcam)": "ESP32 (webcam)",
-  "ESP8266 (generic)": "ESP8266 (generic)",
-  "SonOff Zigbee Bridge": "SonOff Zigbee Bridge",
     
   "": ""
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -105,5 +105,12 @@
 
   "stepVersionCompProgress": "Compiling progress",
 
+  "ESP32 (generic)"; "ESP32 (generic)",
+  "ESP32 (M5Stack Core2)"; "ESP32 (M5Stack Core2)",
+  "ESP32 (odroid-go)"; "ESP32 (odroid-go)",
+  "ESP32 (webcam)"; "ESP32 (webcam)",
+  "ESP8266 (generic)"; "ESP8266 (generic)",
+  "SonOff Zigbee Bridge"; "SonOff Zigbee Bridge",
+    
   "": ""
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -105,12 +105,12 @@
 
   "stepVersionCompProgress": "Compiling progress",
 
-  "ESP32 (generic)"; "ESP32 (generic)",
-  "ESP32 (M5Stack Core2)"; "ESP32 (M5Stack Core2)",
-  "ESP32 (odroid-go)"; "ESP32 (odroid-go)",
-  "ESP32 (webcam)"; "ESP32 (webcam)",
-  "ESP8266 (generic)"; "ESP8266 (generic)",
-  "SonOff Zigbee Bridge"; "SonOff Zigbee Bridge",
+  "ESP32 (generic)": "ESP32 (generic)",
+  "ESP32 (M5Stack Core2)": "ESP32 (M5Stack Core2)",
+  "ESP32 (odroid-go)": "ESP32 (odroid-go)",
+  "ESP32 (webcam)": "ESP32 (webcam)",
+  "ESP8266 (generic)": "ESP8266 (generic)",
+  "SonOff Zigbee Bridge": "SonOff Zigbee Bridge",
     
   "": ""
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -104,12 +104,5 @@
 
   "stepVersionCompProgress": "Progresso compilazione",
 
-  "ESP32 (generic)": "ESP32 (generic)",
-  "ESP32 (M5Stack Core2)": "ESP32 (M5Stack Core2)",
-  "ESP32 (odroid-go)": "ESP32 (odroid-go)",
-  "ESP32 (webcam)": "ESP32 (webcam)",
-  "ESP8266 (generic)": "ESP8266 (generic)",
-  "SonOff Zigbee Bridge": "SonOff Zigbee Bridge",
-
   "": ""
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -104,12 +104,12 @@
 
   "stepVersionCompProgress": "Progresso compilazione",
 
-  "ESP32 (generic)"; "ESP32 (generic)",
-  "ESP32 (M5Stack Core2)"; "ESP32 (M5Stack Core2)",
-  "ESP32 (odroid-go)"; "ESP32 (odroid-go)",
-  "ESP32 (webcam)"; "ESP32 (webcam)",
-  "ESP8266 (generic)"; "ESP8266 (generic)",
-  "SonOff Zigbee Bridge"; "SonOff Zigbee Bridge",
+  "ESP32 (generic)": "ESP32 (generic)",
+  "ESP32 (M5Stack Core2)": "ESP32 (M5Stack Core2)",
+  "ESP32 (odroid-go)": "ESP32 (odroid-go)",
+  "ESP32 (webcam)": "ESP32 (webcam)",
+  "ESP8266 (generic)": "ESP8266 (generic)",
+  "SonOff Zigbee Bridge": "SonOff Zigbee Bridge",
 
   "": ""
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -104,5 +104,12 @@
 
   "stepVersionCompProgress": "Progresso compilazione",
 
+  "ESP32 (generic)"; "ESP32 (generic)",
+  "ESP32 (M5Stack Core2)"; "ESP32 (M5Stack Core2)",
+  "ESP32 (odroid-go)"; "ESP32 (odroid-go)",
+  "ESP32 (webcam)"; "ESP32 (webcam)",
+  "ESP8266 (generic)"; "ESP8266 (generic)",
+  "SonOff Zigbee Bridge"; "SonOff Zigbee Bridge",
+
   "": ""
 }


### PR DESCRIPTION
@benzino77 

Rearrange the order of board (first ESP 32 from generic than the other ESP2 baords with "(" and ")" in alphabetical order. 
Then ESP2866
Then Zigbee

Normalized the decription with use of "(" and ")" for the specfication.
Add // comment for ESP2866

Thanks.