### PR TITLE
Update serviceWorker.js

### DIFF
--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -122,9 +122,13 @@ export function register(config) {
 }
 
 export function unregister() {
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.ready.then((registration) => {
-      registration.unregister();
-    });
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.ready
+      .then((registration) => {
+        registration.unregister();
+      })
+      .catch((error) => {
+        console.log('Error during service worker unregister:', error);
+      })
   }
 }


### PR DESCRIPTION
Firefox gives `Uncaught (in promise) DOMException: The operation is insecure.` error if you have **Clear History when Firefox Exits** checked.