### PR TITLE
better handling languages

### DIFF
--- a/src/components/AppStepper/VersionStep/VersionSelector.js
+++ b/src/components/AppStepper/VersionStep/VersionSelector.js
@@ -7,7 +7,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import { FormattedMessage } from 'react-intl';
 
 function VersionSelector(props) {
-  const { name, classes, label, value, onChange, items, locale } = props;
+  const { name, classes, label, value, onChange, items, guiLanguage } = props;
 
   const inProps = {
     name,
@@ -39,7 +39,7 @@ function VersionSelector(props) {
                   <FormattedMessage id={item.name}>
                     {(text) => {
                       const suffix =
-                        locale !== item.value.split('_')[0]
+                        guiLanguage !== item.value.split('_')[0]
                           ? ` / ${item.nativeName}`
                           : '';
                       return `${text}${suffix}`;
@@ -56,7 +56,7 @@ function VersionSelector(props) {
 }
 
 VersionSelector.defaultProps = {
-  locale: '',
+  guiLanguage: '',
 };
 
 VersionSelector.propTypes = {
@@ -66,7 +66,7 @@ VersionSelector.propTypes = {
   value: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
   items: PropTypes.oneOfType([PropTypes.array]).isRequired,
   onChange: PropTypes.func.isRequired,
-  locale: PropTypes.string,
+  guiLanguage: PropTypes.string,
 };
 
 export default VersionSelector;

--- a/src/components/AppStepper/VersionStep/VersionStep.js
+++ b/src/components/AppStepper/VersionStep/VersionStep.js
@@ -16,28 +16,11 @@ class VersionStep extends Component {
   constructor(props) {
     super(props);
 
-    // Search the current locale of browser on languages
-    const browserLocale = navigator.language.toLowerCase();
-
-    let languageIndex = languages.findIndex((element) =>
-      element.value.toLowerCase().includes(browserLocale.replace('-', '_'))
-    );
-    // Search the language part only
-    if (languageIndex === -1) {
-      languageIndex = languages.findIndex((element) =>
-        element.value.toLowerCase().includes(browserLocale.split(/[-_]/)[0])
-      );
-    }
-    // Set English if not found current locale of browser on languages
-    if (languageIndex === -1) {
-      languageIndex = languages.findIndex((element) =>
-        element.value.includes('en_GB')
-      );
-    }
+    const { tasmotaLanguage } = this.props;
 
     this.state = {
       tasmotaVersion: 'development',
-      MY_LANGUAGE: languages[languageIndex].value,
+      MY_LANGUAGE: tasmotaLanguage,
       message: '',
     };
     this.handleChange = this.handleChange.bind(this);
@@ -68,7 +51,7 @@ class VersionStep extends Component {
       repoTags,
       compiling,
       compileHandler,
-      locale,
+      guiLanguage,
       ...other
     } = this.props;
 
@@ -97,7 +80,7 @@ class VersionStep extends Component {
               label={<FormattedMessage id="stepVersionLanguage" />}
               onChange={this.handleChange}
               classes={classes}
-              locale={locale}
+              guiLanguage={guiLanguage}
             />
           </form>
           <div className={classes.actionsContainer}>
@@ -135,7 +118,8 @@ VersionStep.propTypes = {
   compiling: PropTypes.bool.isRequired,
   compileHandler: PropTypes.func.isRequired,
   backHandler: PropTypes.func.isRequired,
-  locale: PropTypes.string.isRequired,
+  guiLanguage: PropTypes.string.isRequired,
+  tasmotaLanguage: PropTypes.string.isRequired,
 };
 
 export default VersionStep;

--- a/src/components/TopAppBar/TopAppBar.js
+++ b/src/components/TopAppBar/TopAppBar.js
@@ -28,8 +28,8 @@ class TopAppBar extends Component {
     this.setState({ anchorEl: event.currentTarget });
   };
 
-  handleClose = (lang, locale) => {
-    if (lang && lang !== locale) {
+  handleClose = (lang, guiLanguage) => {
+    if (lang && lang !== guiLanguage) {
       const { changeLanguage } = this.props;
       changeLanguage(lang);
     }
@@ -37,7 +37,7 @@ class TopAppBar extends Component {
   };
 
   render() {
-    const { classes, locale, changeLanguage, ...other } = this.props;
+    const { classes, guiLanguage, changeLanguage, ...other } = this.props;
     const { version, anchorEl } = this.state;
 
     return (
@@ -62,7 +62,7 @@ class TopAppBar extends Component {
                 variant="body2"
                 className={classes.language}
               >
-                {allMessages[locale].nativeName}
+                {allMessages[guiLanguage].nativeName}
                 <LanguageIcon className={classes.rightIcon} />
               </Typography>
             </div>
@@ -81,9 +81,9 @@ class TopAppBar extends Component {
                 .map((lang) => {
                   return (
                     <MenuItem
-                      onClick={() => this.handleClose(lang, locale)}
+                      onClick={() => this.handleClose(lang, guiLanguage)}
                       key={lang}
-                      selected={locale === lang}
+                      selected={guiLanguage === lang}
                     >
                       <img
                         src={allMessages[lang].flag}
@@ -106,7 +106,7 @@ class TopAppBar extends Component {
 
 TopAppBar.propTypes = {
   classes: PropTypes.oneOfType([PropTypes.object]).isRequired,
-  locale: PropTypes.string.isRequired,
+  guiLanguage: PropTypes.string.isRequired,
   changeLanguage: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
- centralize finding languages for TasmoCompiler and Tasmota
- respect user's browser language preference
- fix select pt_PT for Tasmota language (so far a user with 'pt' locale got pt_BR because it comes first from Languages.js)