### PR TITLE
added saving of network credentials

### DIFF
--- a/src/components/AppStepper/ClearButton.js
+++ b/src/components/AppStepper/ClearButton.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Button from '@material-ui/core/Button';
+import { FormattedMessage } from 'react-intl';
+
+function ClearButton(props) {
+  const { disabled, onClick } = props;
+  return (
+    <Button
+      disabled={disabled}
+      variant="contained"
+      color="primary"
+      onClick={onClick}
+    >
+      <FormattedMessage id="btnClear" />
+    </Button>
+  );
+}
+
+ClearButton.propTypes = {
+  disabled: PropTypes.bool.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+export default ClearButton;

--- a/src/components/AppStepper/WifiStep.js
+++ b/src/components/AppStepper/WifiStep.js
@@ -8,6 +8,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import Typography from '@material-ui/core/Typography';
 
 import NextButton from './NextButton';
+import ClearButton from './ClearButton';
 import BackButton from './BackButton';
 import TextFieldComponent from './TextFieldComponent';
 import InputAdornment from '@material-ui/core/InputAdornment';
@@ -29,9 +30,17 @@ class WifiStep extends Component {
       showPassword: false,
       staticIPEnabled: false,
     };
+ 
+    if (localStorage.getItem("network") !== null) {
+      this.state = JSON.parse(window.localStorage.getItem("network"));
+      // do not show password per default, ever
+      this.state.showPassword = false;
+    }
+  
     this.handleChange = this.handleChange.bind(this);
     this.handleChangeCheckBox = this.handleChangeCheckBox.bind(this);
     this.handleNext = this.handleNext.bind(this);
+    this.handleClear = this.handleClear.bind(this);
     this.handleBack = this.handleBack.bind(this);
     this.handleClickShowPassword = this.handleClickShowPassword.bind(this);
     this.handleMouseDownPassword = this.handleMouseDownPassword.bind(this);
@@ -62,9 +71,23 @@ class WifiStep extends Component {
 
   handleNext() {
     const { nextHandler } = this.props;
+    window.localStorage.setItem("network", JSON.stringify(this.state))
+
     nextHandler({ network: this.state });
   }
-
+  handleClear() {
+    this.setState({
+      STA_SSID1: '',
+      STA_PASS1: '',
+      WIFI_IP_ADDRESS: '',
+      WIFI_SUBNETMASK: '',
+      WIFI_GATEWAY: '',
+      WIFI_DNS: '',
+      showPassword: false,
+      staticIPEnabled: false,
+    });
+    window.localStorage.removeItem("network");
+  }
   handleBack() {
     const { backHandler } = this.props;
     backHandler();
@@ -174,6 +197,9 @@ class WifiStep extends Component {
           <div className={classes.actionsContainer}>
             <div className={classes.wrapper}>
               <BackButton disabled={false} onClick={this.handleBack} />
+            </div>
+            <div className={classes.wrapper}>
+              <ClearButton disabled={false} onClick={this.handleClear} />
             </div>
             <div className={classes.wrapper}>
               <NextButton disabled={false} onClick={this.handleNext} />

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -6,6 +6,7 @@
   "btnDownloadSrc": "Stažení zdrojového kódu",
   "btnRefreshSrc": "Aktualizace zdrojového kódu",
   "btnNext": "Další",
+  "btnClear": "Clear",
   "btnBack": "Zpět",
   "btnCompile": "Kompilace",
 

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -6,6 +6,7 @@
   "btnDownloadSrc": "Quellcode herunterladen",
   "btnRefreshSrc": "Quellcode aktualisieren",
   "btnNext": "Weiter",
+  "btnClear": "Löschen",
   "btnBack": "Zurück",
   "btnCompile": "Kompilieren",
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -6,6 +6,7 @@
   "btnDownloadSrc": "Download source",
   "btnRefreshSrc": "Refresh source",
   "btnNext": "Next",
+  "btnClear": "Clear",
   "btnBack": "Back",
   "btnCompile": "Compile",
 

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -6,6 +6,7 @@
   "btnDownloadSrc": "Descargar código",
   "btnRefreshSrc": "Actualizar código",
   "btnNext": "Siguiente",
+  "btnClear": "Clear",
   "btnBack": "Atrás",
   "btnCompile": "Compilar",
 

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -6,6 +6,7 @@
   "btnDownloadSrc": "Forrás letöltése",
   "btnRefreshSrc": "Forrás frissítése",
   "btnNext": "Tovább",
+  "btnClear": "Clear",
   "btnBack": "Vissza",
   "btnCompile": "Fordítás",
 

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -6,6 +6,7 @@
   "btnDownloadSrc": "Download codice sorgente",
   "btnRefreshSrc": "Aggiorna codice sorgente",
   "btnNext": "Avanti",
+  "btnClear": "Clear",
   "btnBack": "Indietro",
   "btnCompile": "Compila",
 

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -6,6 +6,7 @@
   "btnDownloadSrc": "Pobierz żródła",
   "btnRefreshSrc": "Odśwież źródła",
   "btnNext": "Następny",
+  "btnClear": "Clear",
   "btnBack": "Poprzedni",
   "btnCompile": "Kompiluj",
 

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -6,6 +6,7 @@
   "btnDownloadSrc": "Baixe o código fonte",
   "btnRefreshSrc": "Atualizar o código-fonte",
   "btnNext": "Próximo",
+  "btnClear": "Clear",
   "btnBack": "Voltar",
   "btnCompile": "Compilar",
 


### PR DESCRIPTION
Works like a charm. As the WIFI settings might never have fields added, this can work savely. For the other fields, we should check if the saved information is still compatible with the current release. I could think of storing the release version with the actual values. That simplifies checking for compatibility given that the release version changes whenever we also add/ remove fields.

I was not comfortable using Google Translator for the Clear Button name. It does not even work correctly between english and german. Hence I have put the english variant in for all other languages.