### PR TITLE
chore: update Dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM node:12.16.2-buster-slim
 LABEL maintainer="Piotr Antczak <antczak.piotr@gmail.com>"
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python3 git python3-setuptools && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip && pip3 install platformio && \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y python3 git python3-setuptools && \
+  DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y python3-pip && pip3 install --no-cache-dir platformio && \
   DEBIAN_FRONTEND=noninteractive apt-get clean && \
   yarn global add nodemon && \
   cd /tmp && git clone https://github.com/arendst/Tasmota.git && \
-  rm -rf /var/lib/apt/lists/* 
+  rm -rf /var/lib/apt/lists/*
 ADD public /tasmocompiler/public/
 ADD server /tasmocompiler/server/
 ADD src /tasmocompiler/src/


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

Summary of the changes:
* I added the `--no-cache-dir` to the `pip` command to disable the package cache.
* I added the `--no-install-recommends` to with apt-get in order to not install unnecessary packages and reduce the image size.


Impact on the image size:
* Image size before repair: 1.18 GB
* Image size after repair: 887.29 MB
* Difference: 323.78 MB (26.73%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,