### PR TITLE
add sen5x to available features - air sensors

### DIFF
--- a/FEATURES_DESC.md
+++ b/FEATURES_DESC.md
@@ -17,7 +17,7 @@
 | `USE_LE01MR`       | `USE_VINDRIKTNING` | `USE_MAX31865`                        | `USE_DISPLAY_SSD1331`   |                  |                |
 | `USE_BL09XX`       | `USE_SCD40`        | `USE_HIH6`                            |                         |                  |                |
 | `USE_TELEINFO`     | `USE_HM330X`       | `USE_DHT12`                           |                         |                  |                |
-| `USE_IEM3000`      |                    | `USE_DS1624`                          |                         |                  |                |
+| `USE_IEM3000`      | `USE_SEN5X`        | `USE_DS1624`                          |                         |                  |                |
 | `USE_WE517`        |                    | `USE_AHT1x`                           |                         |                  |                |
 | `USE_ENERGY_DUMMY` |                    | `USE_HDC1080`                         |                         |                  |                |
 | `USE_IEM3000`      |                    | `USE_MCP9808`                         |                         |                  |                |

--- a/src/components/AppStepper/FeaturesStep/AvailableFeatures.js
+++ b/src/components/AppStepper/FeaturesStep/AvailableFeatures.js
@@ -14,6 +14,7 @@ const availableFeatures = [
       'USE_CCS811',
       'USE_SCD30',
       'USE_SPS30',
+      'USE_SEN5X',
       'USE_HPMA',
       'USE_IAQ',
       'USE_T67XX',


### PR DESCRIPTION
This adds the USE_SEN5X define to Air Sensors feature.
It's for the Sensirion SEN55/54/50.