### PR TITLE
Update Dockerfile to expose port 3000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,4 @@ RUN cd /tasmocompiler && npm ci && npm run build
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 WORKDIR /tasmocompiler
 ENTRYPOINT ["nodemon", "server/app.js"]
+EXPOSE 3000/tcp


### PR DESCRIPTION
I've updated the docker file to expose the port 3000, so that the docker image can be used with Docker Desktop.